### PR TITLE
Implement simple table for data values

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,7 +1,5 @@
 {
   "baseUrl": "http://localhost:8080",
   "video": false,
-  "fixturesFolder": false,
-  "supportFile": false,
   "defaultCommandTimeout": 8000
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -932,7 +932,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -945,7 +945,7 @@
         },
         "supports-color": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
@@ -2612,6 +2612,19 @@
       "integrity": "sha512-WCxx1ixHT0GQU9hb0KI/mhgRQhnU+U3GvwY6ZvVjYq8rsihIGoaIOUbY0yMPBxLH5MDtr0kz3fisWGNcbWW7Jw==",
       "requires": {
         "object-assign": "4.x"
+      }
+    },
+    "ag-grid-community": {
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/ag-grid-community/-/ag-grid-community-20.0.0.tgz",
+      "integrity": "sha512-KOvUnZsf1FY/0wt77xNRHJl76nxGwMuVZpEAAQvAsv+TrODXETSP9JcJskVBjr+s5VLvGaxJNfV7JQTc1ZPS5w=="
+    },
+    "ag-grid-react": {
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/ag-grid-react/-/ag-grid-react-20.0.0.tgz",
+      "integrity": "sha512-0DAuUsF3qtI6cndtC1UkMT3h9iiIrK/ecgZZJme65h4Lyp08j5qz+u+jFWWm60LGnLL6+0uqPWLZoOA+TSgUpg==",
+      "requires": {
+        "prop-types": "^15.6.2"
       }
     },
     "ajv": {
@@ -5391,7 +5404,7 @@
       "dependencies": {
         "globby": {
           "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
           "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
           "dev": true,
           "requires": {
@@ -5404,7 +5417,7 @@
           "dependencies": {
             "pify": {
               "version": "2.3.0",
-              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+              "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
               "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
               "dev": true
             }
@@ -7973,7 +7986,7 @@
             },
             "is-accessor-descriptor": {
               "version": "0.1.6",
-              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+              "resolved": "http://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
               "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
               "dev": true,
               "requires": {
@@ -7993,7 +8006,7 @@
             },
             "is-data-descriptor": {
               "version": "0.1.4",
-              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+              "resolved": "http://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
               "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
               "dev": true,
               "requires": {
@@ -9601,7 +9614,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -9623,7 +9636,7 @@
         },
         "supports-color": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
@@ -9659,7 +9672,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -9687,7 +9700,7 @@
         },
         "supports-color": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
@@ -9713,7 +9726,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -9726,7 +9739,7 @@
         },
         "supports-color": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
@@ -9882,7 +9895,7 @@
       "dependencies": {
         "ansi-escapes": {
           "version": "1.4.0",
-          "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
           "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
           "dev": true
         }
@@ -10020,7 +10033,7 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
     },
@@ -11026,7 +11039,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -11039,7 +11052,7 @@
         },
         "supports-color": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
@@ -11354,7 +11367,7 @@
       "dependencies": {
         "async": {
           "version": "1.5.2",
-          "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
           "dev": true
         },

--- a/package.json
+++ b/package.json
@@ -109,6 +109,8 @@
   },
   "dependencies": {
     "@svgr/webpack": "^4.1.0",
+    "ag-grid-community": "^20.0.0",
+    "ag-grid-react": "^20.0.0",
     "chart.js": "^2.7.3",
     "chartjs": "^0.3.24",
     "immutable": "^3.8.2",

--- a/src/components/app.sass
+++ b/src/components/app.sass
@@ -5,8 +5,16 @@
   right: 0
   bottom: 0
   display: flex
-  align-items: center
+  align-items: flex-start
   justify-content: center
   color: #242424
   background-color: #dfdfdf
 
+
+  .section
+    width: 900px
+    min-height: 420px
+    margin-top: 40px
+    background-color: white
+    padding: 20px
+    border-radius: 20px

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -1,9 +1,10 @@
 import { inject, observer } from "mobx-react";
 import * as React from "react";
 import { BaseComponent, IBaseProps } from "./base";
-import { Text } from "./text";
 import { ChartDisplay } from "./charts/chart-display";
 import { SimulationControls } from "./simulation-controls";
+import { DamData } from "./dam-data";
+
 import "./app.sass";
 
 interface IProps extends IBaseProps {}
@@ -17,10 +18,24 @@ export class AppComponent extends BaseComponent<IProps, IState> {
     const {ui} = this.stores;
     return (
       <div className="app">
-        <Text text={ui.sampleText} />
-        <canvas id="canvas_for_cartoon" width="600" height="340" />
-        <ChartDisplay />
-        <SimulationControls />
+        <div className="controls">
+          <SimulationControls />
+        </div>
+        {ui.displayMode === "Simulation" &&
+          <div className="section simulation">
+            <canvas id="canvas_for_cartoon" width="600" height="340" />
+          </div>
+        }
+        {ui.displayMode === "Graph" &&
+          <div className="section chart">
+            <ChartDisplay />
+          </div>
+        }
+        {ui.displayMode === "Table" &&
+          <div className="section table">
+            <DamData />
+          </div>
+        }
       </div>
     );
   }

--- a/src/components/dam-data.sass
+++ b/src/components/dam-data.sass
@@ -1,0 +1,15 @@
+.dam-data-grid
+  height: 500px
+  font-size: 0.7em
+  display: flex
+  flex-direction: column
+
+  .ag-header-cell
+    padding: 2px
+  .ag-header-cell-label
+    text-overflow: clip
+    overflow: visible
+    white-space: normal
+    font-weight: 700
+  .ag-cell
+    padding: 2px

--- a/src/components/dam-data.tsx
+++ b/src/components/dam-data.tsx
@@ -1,0 +1,66 @@
+import { inject, observer } from "mobx-react";
+import * as React from "react";
+import { BaseComponent, IBaseProps } from "./base";
+import { AgGridReact } from "ag-grid-react";
+import { ColDef, ValueFormatterParams, AgGridEvent } from "ag-grid-community";
+import "ag-grid-community/dist/styles/ag-grid.css";
+import "ag-grid-community/dist/styles/ag-theme-balham.css";
+import "./dam-data.sass";
+
+interface IProps extends IBaseProps {}
+interface IState { }
+
+const visibleColumns = [
+  "Year",
+  "Season",
+  "FarmLakeArea",
+  "StartSeasonSurfaceArea",
+  "StartSeasonVolume",
+  "EndSeasonSurfaceArea",
+  "EndSeasonVolume",
+  "CornYieldFarmville",
+  "CornYieldAgriburg"];
+
+@inject("stores")
+@observer
+export class DamData extends BaseComponent<IProps, IState> {
+
+  public render() {
+    const { riverData } = this.stores;
+    const cols = this.getDataColumns();
+    return (
+      <div className="dam-data-grid">
+        <AgGridReact columnDefs={cols} rowData={riverData.allCurrentData} headerHeight={48}
+          onGridReady={this.onGridReady} />
+      </div>
+    );
+  }
+
+  private getDataColumns = (): ColDef[] => {
+    const { riverData } = this.stores;
+    const allData = riverData.allCurrentData;
+
+    const cols: ColDef[] = [];
+    Object.keys(allData[0]).map(d => {
+      if (visibleColumns.indexOf(d) > -1) {
+        const headerName = d.replace(/([A-Z])/g, " $1").trim();
+        const c: ColDef = { headerName, field: d, valueFormatter: this.numberFormatter };
+        cols.push(c);
+      }
+    });
+    return cols;
+  }
+
+  private numberFormatter = (v: ValueFormatterParams): string => {
+    if (typeof (v.value) === "string") return v.value;
+    const roundedValue = Math.round(v.value);
+    return roundedValue.toString();
+  }
+
+  private onGridReady = (params: AgGridEvent) => {
+    const gridApi = params.api;
+    if (gridApi) {
+      gridApi.sizeColumnsToFit();
+    }
+  }
+}

--- a/src/components/simulation-controls.sass
+++ b/src/components/simulation-controls.sass
@@ -4,3 +4,9 @@
   border-radius: 10px
   margin: 10px
   padding: 10px
+  font-size: 0.8em
+
+  div
+    padding-top: 4px
+  .display-mode
+    font-weight: 700

--- a/src/components/simulation-controls.tsx
+++ b/src/components/simulation-controls.tsx
@@ -11,7 +11,7 @@ interface IState {}
 @observer
 export class SimulationControls extends BaseComponent<IProps, IState> {
   public render() {
-    const { riverData } = this.stores;
+    const { riverData, ui } = this.stores;
     return (
       <div className="simulation-controls">
         <div>Diversion percentage: {riverData.flowPercentage}</div>
@@ -34,6 +34,13 @@ export class SimulationControls extends BaseComponent<IProps, IState> {
           <option value="Summer">Summer</option>
         </select>
         <div>End of Season Area: {riverData.currentYearData[0].EndSeasonSurfaceArea}</div>
+        <div className="display-mode">Display Mode</div>
+        <div><input type="radio" id="displayModeSim" name="displayMode" value="Simulation"
+          checked={ui.displayMode === "Simulation"} onChange={this.handleDisplayModeChange}/>Simulation</div>
+        <div><input type="radio" id="displayModeGraph" name="displayMode" value="Graph"
+          checked={ui.displayMode === "Graph"} onChange={this.handleDisplayModeChange}/>Graph</div>
+        <div><input type="radio" id="displayModeTable" name="displayMode" value="Table"
+          checked={ui.displayMode === "Table"} onChange={this.handleDisplayModeChange}/>Table</div>
       </div>
     );
   }
@@ -49,5 +56,9 @@ export class SimulationControls extends BaseComponent<IProps, IState> {
     const { riverData } = this.stores;
     const flowPercentage = parseInt(e.currentTarget.value, 10);
     riverData.setFlowPercentage(isNaN(flowPercentage) ? 0 : flowPercentage);
+  }
+  private handleDisplayModeChange = (e: React.FormEvent<HTMLInputElement>) => {
+    const { ui } = this.stores;
+    ui.setDisplayMode(e.currentTarget.value);
   }
 }

--- a/src/models/dam.ts
+++ b/src/models/dam.ts
@@ -4,6 +4,23 @@ import * as dam25 from "../data/dam25.json";
 import * as dam50 from "../data/dam50.json";
 import * as dam75 from "../data/dam75.json";
 
+const dataByFlow = (flowPercentage: number): SeasonData[] => {
+  let allData: SeasonData[];
+  switch (flowPercentage) {
+    case 0:
+      allData = dam0 as SeasonData[];
+    case 25:
+      allData = dam25 as SeasonData[];
+    case 50:
+      allData = dam50 as SeasonData[];
+    case 75:
+      allData = dam75 as SeasonData[];
+    default:
+      allData = dam0 as SeasonData[];
+  }
+  return allData;
+};
+
 export interface SeasonData {
     Year: number;
     Season: string;
@@ -45,33 +62,10 @@ export const DamModel = types
   })
   .views(self => ({
     get allCurrentData(): SeasonData[] {
-      switch (self.flowPercentage) {
-        case 0:
-          return dam0 as SeasonData[];
-        case 25:
-          return dam25 as SeasonData[];
-        case 50:
-          return dam50 as SeasonData[];
-        case 75:
-          return dam75 as SeasonData[];
-        default:
-          return dam0 as SeasonData[];
-      }
+      return dataByFlow(self.flowPercentage);
     },
     get currentYearData(): SeasonData[] {
-      let allData: SeasonData[];
-      switch (self.flowPercentage) {
-        case 0:
-          allData = dam0 as SeasonData[];
-        case 25:
-          allData = dam25 as SeasonData[];
-        case 50:
-          allData = dam50 as SeasonData[];
-        case 75:
-          allData = dam75 as SeasonData[];
-        default:
-          allData = dam0 as SeasonData[];
-      }
+      const allData = dataByFlow(self.flowPercentage);
       return allData.filter(d => d.Year === self.currentYear && d.Season === self.currentSeason);
     }
   }))

--- a/src/models/ui.test.ts
+++ b/src/models/ui.test.ts
@@ -8,19 +8,19 @@ describe("ui model", () => {
   });
 
   it("has default values", () => {
-    expect(ui.sampleText).toBe("Hello World");
+    expect(ui.displayMode).toBe("Graph");
   });
 
   it("uses override values", () => {
     ui = UIModel.create({
-      sampleText: "foo"
+      displayMode: "Chart"
     });
-    expect(ui.sampleText).toBe("foo");
+    expect(ui.displayMode).toBe("Chart");
   });
 
   it("sets new values", () => {
-    ui.setSampleText("bar");
-    expect(ui.sampleText).toBe("bar");
+    ui.setDisplayMode("Simulation");
+    expect(ui.displayMode).toBe("Simulation");
   });
 
 });

--- a/src/models/ui.ts
+++ b/src/models/ui.ts
@@ -2,12 +2,12 @@ import { types } from "mobx-state-tree";
 
 export const UIModel = types
   .model("UI", {
-    sampleText: "Hello World"
+    displayMode: "Graph"
   })
   .actions((self) => {
     return {
-      setSampleText(text: string) {
-        self.sampleText = text;
+      setDisplayMode(text: string) {
+        self.displayMode = text;
       }
     };
   });


### PR DESCRIPTION
This PR introduces a simple data table component that we can position and style later as we bring pieces together. The data shown is only a subset of the total available data and can be styled differently, with value formatting available to whatever style we choose (so we can convert 123123123 to 123 Million etc)
Looking at the table it may be worth only including the Summer seasonal data for end-of-year results analysis, but this may require PI feedback.

Also added changes to Cypress configuration following conversation on Slack dev channel.