### PR TITLE
Link Chart and Table display

### DIFF
--- a/src/components/app.sass
+++ b/src/components/app.sass
@@ -31,30 +31,15 @@
     height: 100%
     overflow: hidden
 
-    .left-panel
-      flex-grow: 0
-      flex-shrink: 0
-      flex-basis: $left-nav-panel-width
-      display: flex
-      flex-direction: column
-      background-color: $left-nav-bgcolor
-      margin-right: $component-margin
-      .controls
-        display: flex
-        flex-direction: column
-        align-items: center
-
     .main-content
       display: grid
-      grid-template-columns: 100%
-      grid-template-rows: 65% 35%
+      grid-template-columns: 65% 35%
       color: $main-content-color
       background-color: $main-content-bgcolor
       width: 100%
+      height: 100%
 
       .section
-        display: grid
-        grid-template-rows: 100%
         color: $color-nav-cinder-dark3
         background-color: $color-white
         border: $component-border-width solid white
@@ -64,23 +49,28 @@
 
         &.simulation
           position: relative
+          display: grid
+          grid-template-rows: 70% 30%
           order: 0
+          .subsection
+            overflow: auto
+
         &.chart-table
           display: grid
-          grid-template-columns: 30% 70%
+          grid-template-rows: 40% 60%
           flex: 1 1 auto
 
-        .subsection
-          overflow: hidden
-          height: 100%
-          &.table
-            overflow-y: auto
-          &.chart
-            position: relative
-            overflow-y: auto
+          .subsection
+            overflow: hidden
 
-          .chart-options
-            position: absolute
-            top: 0px
-            right: 0px
-            z-index: 1
+            &.table
+              overflow-y: auto
+            &.chart
+              position: relative
+              overflow-y: auto
+
+            .chart-options
+              position: absolute
+              top: 0px
+              right: 0px
+              z-index: 1

--- a/src/components/app.sass
+++ b/src/components/app.sass
@@ -50,10 +50,12 @@
         &.simulation
           position: relative
           display: grid
-          grid-template-rows: 70% 30%
+          grid-template-rows: 60% 40%
           order: 0
           .subsection
             overflow: auto
+            &.sim-controls
+              z-index: 1
 
         &.chart-table
           display: grid

--- a/src/components/app.sass
+++ b/src/components/app.sass
@@ -83,3 +83,4 @@
             position: absolute
             top: 0px
             right: 0px
+            z-index: 1

--- a/src/components/app.sass
+++ b/src/components/app.sass
@@ -45,32 +45,41 @@
         align-items: center
 
     .main-content
-      flex-grow: 1
       display: grid
-      grid-template-rows: 1fr
+      grid-template-columns: 100%
+      grid-template-rows: 65% 35%
       color: $main-content-color
       background-color: $main-content-bgcolor
+      width: 100%
 
       .section
+        display: grid
+        grid-template-rows: 100%
         color: $color-nav-cinder-dark3
-        background-color: $section-bgcolor
+        background-color: $color-white
         border: $component-border-width solid white
         border-radius: $component-border-radius
-        margin: $double-two-up-margin
-        border-radius: $component-border-radius
+        margin: 0
+        border-radius: 0
 
         &.simulation
           position: relative
-          min-height: 40vh
+          order: 0
+        &.chart-table
+          display: grid
+          grid-template-columns: 30% 70%
+          flex: 1 1 auto
 
-        .header
-          flex: 0 0 $section-header-height
-          display: flex
-          align-items: center
-          font-family: $font-stack
-          color: $section-header-color
-          text-align: center
-          background-color: $section-header-bgcolor
-          border-top-left-radius: $component-border-radius
-          border-top-right-radius: $component-border-radius
-          padding: $quarter-padding
+        .subsection
+          overflow: hidden
+          height: 100%
+          &.table
+            overflow-y: auto
+          &.chart
+            position: relative
+            overflow-y: auto
+
+          .chart-options
+            position: absolute
+            top: 0px
+            right: 0px

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -36,19 +36,17 @@ export class AppComponent extends BaseComponent<{}, {}> {
                 <SizeMe monitorHeight={true}>
                   {({ size }: ISize) =>
                     <PictureArea
-                      parentWidth={size.width ? size.width : 0} parentHeight={size.height ? size.height : 1} />
+                      parentWidth={size.width ? size.width : 600} parentHeight={size.height ? size.height : 340} />
                   }
                 </SizeMe>
               </div>
-              {appMode === "dev" &&
-                <div className="subsection sim-controls">
-                  <div className="controls-bottom">
-                    <SimulationControls>
-                      <ControlArea />
-                    </SimulationControls>
-                  </div>
+              <div className="subsection sim-controls">
+                <div className="controls-bottom">
+                  <SimulationControls>
+                    <ControlArea />
+                  </SimulationControls>
                 </div>
-              }
+              </div>
             </div>
             <div className="section chart-table">
               <div className="subsection table">

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -25,31 +25,34 @@ export class AppComponent extends BaseComponent<{}, {}> {
 
   public render() {
 
-    const {ui, appMode} = this.stores;
+    const { ui, appMode } = this.stores;
 
     return (
       <div className="app-container">
         <div className="controls-and-content-container">
-          {appMode === "dev" &&
-            <div className="left-panel">
-              <div className="controls">
-              <SimulationControls>
-                <ControlArea />
-              </SimulationControls>
+          <div className="main-content">
+            <div className="section simulation">
+              <div className="subsection simulation">
+                <SizeMe monitorHeight={true}>
+                  {({ size }: ISize) =>
+                    <PictureArea
+                      parentWidth={size.width ? size.width : 0} parentHeight={size.height ? size.height : 1} />
+                  }
+                </SizeMe>
               </div>
-            </div>
-          }
-        <div className="main-content">
-          <div className="section simulation">
-            <SizeMe monitorHeight={true}>
-              {({ size }: ISize) =>
-                <PictureArea parentWidth={size.width ? size.width : 0} parentHeight={size.height ? size.height : 1} />
+              {appMode === "dev" &&
+                <div className="subsection sim-controls">
+                  <div className="controls-bottom">
+                    <SimulationControls>
+                      <ControlArea />
+                    </SimulationControls>
+                  </div>
+                </div>
               }
-            </SizeMe>
             </div>
             <div className="section chart-table">
               <div className="subsection table">
-              <SizeMe monitorHeight={true}>
+                <SizeMe monitorHeight={true}>
                   {({ size }: ISize) =>
                     <DamData parentWidth={size.width ? size.width : 0}
                       parentHeight={size.height ? size.height : 1} />

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -29,9 +29,6 @@ export class AppComponent extends BaseComponent<{}, {}> {
 
     return (
       <div className="app-container">
-        {appMode !== "embed" &&
-          <div className="top-bar">DAT Cross Dam</div>
-        }
         <div className="controls-and-content-container">
           {appMode === "dev" &&
             <div className="left-panel">
@@ -43,25 +40,31 @@ export class AppComponent extends BaseComponent<{}, {}> {
             </div>
           }
         <div className="main-content">
-            <div className="section simulation">
+          <div className="section simulation">
+            <SizeMe monitorHeight={true}>
+              {({ size }: ISize) =>
+                <PictureArea parentWidth={size.width ? size.width : 0} parentHeight={size.height ? size.height : 1} />
+              }
+            </SizeMe>
+            </div>
+            <div className="section chart-table">
+              <div className="subsection table">
               <SizeMe monitorHeight={true}>
-                {({ size }: ISize) =>
-                  <PictureArea parentWidth={size.width ? size.width : 0} parentHeight={size.height ? size.height : 1} />
-                }
-              </SizeMe>
-          </div>
-          {ui.displayMode === "Graph" &&
-            <div className="section chart">
-              <div className="header">Chart</div>
-              <ChartDisplay />
+                  {({ size }: ISize) =>
+                    <DamData parentWidth={size.width ? size.width : 0}
+                      parentHeight={size.height ? size.height : 1} />
+                  }
+                </SizeMe>
+              </div>
+              <div className="subsection chart">
+                <SizeMe monitorHeight={true}>
+                  {({ size }: ISize) =>
+                    <ChartDisplay parentWidth={size.width ? size.width : 0}
+                      parentHeight={size.height ? size.height : 1} />
+                  }
+                </SizeMe>
+              </div>
             </div>
-          }
-          {ui.displayMode === "Table" &&
-            <div className="section table">
-              <div className="header">Table</div>
-              <DamData />
-            </div>
-            }
           </div>
         </div>
       </div>

--- a/src/components/charts/bar-chart.tsx
+++ b/src/components/charts/bar-chart.tsx
@@ -130,7 +130,7 @@ export class BarChart extends React.Component<IBarProps> {
           options={options}
           height={h}
           width={w}
-          redraw={false}
+          redraw={true}
           data-test="bar"
         />
       );
@@ -141,7 +141,7 @@ export class BarChart extends React.Component<IBarProps> {
           options={options}
           height={h}
           width={w}
-          redraw={false}
+          redraw={true}
           data-test="horizontal-bar"
         />
       );

--- a/src/components/charts/bar-chart.tsx
+++ b/src/components/charts/bar-chart.tsx
@@ -110,12 +110,22 @@ export class BarChart extends React.Component<IBarProps> {
             min: 0,
             max: chartData.minMaxAll.maxA2
           },
+          scaleLabel: {
+            display: true,
+            fontSize: 12,
+            labelString: chartData.a1AxisLabel
+          },
           stacked: true
         }],
         yAxes: [{
           ticks: {
             min: 0,
             max: chartData.minMaxAll.maxA2
+          },
+          scaleLabel: {
+            display: true,
+            fontSize: 12,
+            labelString: chartData.a2AxisLabel
           },
           stacked: true
         }]

--- a/src/components/charts/chart-display.tsx
+++ b/src/components/charts/chart-display.tsx
@@ -99,7 +99,9 @@ export class ChartDisplay extends BaseComponent<IProps, IState> {
       backgroundOpacity: 0.9,
       stack: "CornA",
       fixedMaxA2: 250,
-      fixedMinA2: 0
+      fixedMinA2: 0,
+      a1AxisLabel: "Year",
+      a2AxisLabel: "Corn Yield bu/acre"
     });
 
     const cornFarmvilleDataSet = ChartDataSetModel.create({
@@ -109,7 +111,9 @@ export class ChartDisplay extends BaseComponent<IProps, IState> {
       backgroundOpacity: 0.9,
       stack: "CornF",
       fixedMaxA2: 250,
-      fixedMinA2: 0
+      fixedMinA2: 0,
+      a1AxisLabel: "Year",
+      a2AxisLabel: "Corn Yield bu/acre"
     });
 
     const lakeSurfaceAreaDataSet = ChartDataSetModel.create({
@@ -119,7 +123,9 @@ export class ChartDisplay extends BaseComponent<IProps, IState> {
       backgroundOpacity: 0.9,
       stack: "Lake",
       fixedMaxA2: 90000,
-      fixedMinA2: 0
+      fixedMinA2: 0,
+      a1AxisLabel: "Year",
+      a2AxisLabel: "Surface Area cu.feet"
     });
 
     const chartDataSets: ChartDataSetModelType[] = [];
@@ -138,8 +144,7 @@ export class ChartDisplay extends BaseComponent<IProps, IState> {
 
     const allChartData: ChartDataModelType = ChartDataModel.create({
       name: "Results",
-      dataSets: chartDataSets,
-      labels: []
+      dataSets: chartDataSets
     });
 
     return allChartData;

--- a/src/components/charts/chart-display.tsx
+++ b/src/components/charts/chart-display.tsx
@@ -12,7 +12,10 @@ import {
 } from "../../models/charts/chart-data-set";
 import { ChartDataModelType, ChartDataModel } from "../../models/charts/chart-data";
 
-interface IProps extends IBaseProps {}
+interface IProps extends IBaseProps {
+  parentWidth: number;
+  parentHeight: number;
+}
 interface IState {
   chartType: ChartType;
   chartData: string;
@@ -28,24 +31,28 @@ export class ChartDisplay extends BaseComponent<IProps, IState> {
 
   public render() {
     const { chartType, chartData } = this.state;
+    const { parentWidth, parentHeight } = this.props;
     const { riverData } = this.stores;
     const currentData = dataByFlow(riverData.flowPercentage);
     const charts = this.buildAllCharts(currentData);
 
     return (
-      <div className="chart-test-panel">
+      <div className="chart-panel">
         <div className="content">
-          <select value={chartType} onChange={this.handleChangeSelection} data-test="chart-type">
-            <option value={"line"} data-test="line-option">Line</option>
-            <option value={"horizontalBar"} data-test="horizontalBar-option">Horizontal Bar</option>
-            <option value={"bar"} data-test="bar-option">Bar</option>
-          </select>
-          <select value={chartData} onChange={this.handleChangeDataSelection} data-test="chart-data">
-            <option value={"corn"} data-test="volume-option">Corn Yield</option>
-            <option value={"lake"} data-test="area-option">Lake Surface Area</option>
-          </select>
-          <div>
-            <Chart title="Chart Test" chartData={charts} chartType={chartType} isPlaying={false} />
+          <div className="chart-options">
+            <select value={chartType} onChange={this.handleChangeSelection} data-test="chart-type">
+              <option value={"line"} data-test="line-option">Line</option>
+              <option value={"horizontalBar"} data-test="horizontalBar-option">Horizontal Bar</option>
+              <option value={"bar"} data-test="bar-option">Bar</option>
+            </select>
+            <select value={chartData} onChange={this.handleChangeDataSelection} data-test="chart-data">
+              <option value={"corn"} data-test="volume-option">Corn Yield</option>
+              <option value={"lake"} data-test="area-option">Lake Surface Area</option>
+            </select>
+          </div>
+          <div className="chart-content-container">
+            <Chart title="Chart Test" chartData={charts} chartType={chartType}
+              isPlaying={false} width={parentWidth} height={parentHeight} />
           </div>
         </div>
         <div className="footer"/>

--- a/src/components/charts/chart-display.tsx
+++ b/src/components/charts/chart-display.tsx
@@ -2,7 +2,7 @@ import { inject, observer } from "mobx-react";
 import * as React from "react";
 import { BaseComponent, IBaseProps } from "../base";
 import { Chart, ChartType } from "./chart";
-import { dataByFlow, SeasonData } from "../../data/dam-data-utility";
+import { dataByFlow, dataByFlowByYear, SeasonData } from "../../data/dam-data-utility";
 import {
   DataPointType,
   DataPoint,
@@ -32,7 +32,7 @@ export class ChartDisplay extends BaseComponent<IProps, IState> {
     const { chartType } = this.state;
     const { parentWidth, parentHeight } = this.props;
     const { riverData } = this.stores;
-    const currentData = dataByFlow(riverData.flowPercentage);
+    const currentData = dataByFlowByYear(riverData.flowPercentage, riverData.currentYear);
     const charts = this.buildAllCharts(currentData);
 
     return (

--- a/src/components/charts/chart-display.tsx
+++ b/src/components/charts/chart-display.tsx
@@ -97,7 +97,9 @@ export class ChartDisplay extends BaseComponent<IProps, IState> {
       dataPoints: this.buildChart(sourceData, "Summer", "corna"),
       color: ChartColors[3].hex,
       backgroundOpacity: 0.9,
-      stack: "CornA"
+      stack: "CornA",
+      fixedMaxA2: 250,
+      fixedMinA2: 0
     });
 
     const cornFarmvilleDataSet = ChartDataSetModel.create({
@@ -105,7 +107,9 @@ export class ChartDisplay extends BaseComponent<IProps, IState> {
       dataPoints: this.buildChart(sourceData, "Summer", "cornf"),
       color: ChartColors[1].hex,
       backgroundOpacity: 0.9,
-      stack: "CornF"
+      stack: "CornF",
+      fixedMaxA2: 250,
+      fixedMinA2: 0
     });
 
     const lakeSurfaceAreaDataSet = ChartDataSetModel.create({
@@ -113,7 +117,9 @@ export class ChartDisplay extends BaseComponent<IProps, IState> {
       dataPoints: this.buildChart(sourceData, "Summer", "lake"),
       color: ChartColors[0].hex,
       backgroundOpacity: 0.9,
-      stack: "Lake"
+      stack: "Lake",
+      fixedMaxA2: 90000,
+      fixedMinA2: 0
     });
 
     const chartDataSets: ChartDataSetModelType[] = [];

--- a/src/components/charts/chart-display.tsx
+++ b/src/components/charts/chart-display.tsx
@@ -101,7 +101,8 @@ export class ChartDisplay extends BaseComponent<IProps, IState> {
       fixedMaxA2: 250,
       fixedMinA2: 0,
       a1AxisLabel: "Year",
-      a2AxisLabel: "Corn Yield bu/acre"
+      a2AxisLabel: "Corn Yield bu/acre",
+      maxPoints: 10
     });
 
     const cornFarmvilleDataSet = ChartDataSetModel.create({
@@ -113,7 +114,8 @@ export class ChartDisplay extends BaseComponent<IProps, IState> {
       fixedMaxA2: 250,
       fixedMinA2: 0,
       a1AxisLabel: "Year",
-      a2AxisLabel: "Corn Yield bu/acre"
+      a2AxisLabel: "Corn Yield bu/acre",
+      maxPoints: 10
     });
 
     const lakeSurfaceAreaDataSet = ChartDataSetModel.create({
@@ -125,7 +127,8 @@ export class ChartDisplay extends BaseComponent<IProps, IState> {
       fixedMaxA2: 90000,
       fixedMinA2: 0,
       a1AxisLabel: "Year",
-      a2AxisLabel: "Surface Area cu.feet"
+      a2AxisLabel: "Surface Area cu.feet",
+      maxPoints: 10
     });
 
     const chartDataSets: ChartDataSetModelType[] = [];

--- a/src/components/charts/chart-display.tsx
+++ b/src/components/charts/chart-display.tsx
@@ -18,7 +18,6 @@ interface IProps extends IBaseProps {
 }
 interface IState {
   chartType: ChartType;
-  chartData: string;
 }
 
 @inject("stores")
@@ -26,11 +25,11 @@ interface IState {
 export class ChartDisplay extends BaseComponent<IProps, IState> {
   constructor(props: IProps) {
     super(props);
-    this.state = { chartType: "bar", chartData: "lake" };
+    this.state = { chartType: "bar" };
   }
 
   public render() {
-    const { chartType, chartData } = this.state;
+    const { chartType } = this.state;
     const { parentWidth, parentHeight } = this.props;
     const { riverData } = this.stores;
     const currentData = dataByFlow(riverData.flowPercentage);
@@ -45,7 +44,7 @@ export class ChartDisplay extends BaseComponent<IProps, IState> {
               <option value={"horizontalBar"} data-test="horizontalBar-option">Horizontal Bar</option>
               <option value={"bar"} data-test="bar-option">Bar</option>
             </select>
-            <select value={chartData} onChange={this.handleChangeDataSelection} data-test="chart-data">
+            <select value={riverData.dataView} onChange={this.handleChangeDataSelection} data-test="chart-data">
               <option value={"corn"} data-test="volume-option">Corn Yield</option>
               <option value={"lake"} data-test="area-option">Lake Surface Area</option>
             </select>
@@ -68,9 +67,10 @@ export class ChartDisplay extends BaseComponent<IProps, IState> {
   }
 
   private handleChangeDataSelection = (e: any) => {
+    const { riverData } = this.stores;
     const selectedValue = e.currentTarget.value ? e.currentTarget.value : "lake";
-    if (selectedValue !== this.state.chartData) {
-      this.setState({ chartData:  selectedValue });
+    if (selectedValue !== riverData.dataView) {
+      riverData.setDataView(selectedValue);
     }
   }
 
@@ -90,7 +90,7 @@ export class ChartDisplay extends BaseComponent<IProps, IState> {
   }
 
   private buildAllCharts = (sourceData: SeasonData[]) => {
-    const { chartData } = this.state;
+    const { riverData } = this.stores;
 
     const cornAgriburgDataSet = ChartDataSetModel.create({
       name: "Corn Yield - Agriburg",
@@ -118,7 +118,7 @@ export class ChartDisplay extends BaseComponent<IProps, IState> {
 
     const chartDataSets: ChartDataSetModelType[] = [];
 
-    switch (chartData) {
+    switch (riverData.dataView) {
       case "corn":
         chartDataSets.push(cornAgriburgDataSet);
         chartDataSets.push(cornFarmvilleDataSet);

--- a/src/components/charts/chart.sass
+++ b/src/components/charts/chart.sass
@@ -1,7 +1,7 @@
 @import ../vars
 
 .chart-container
-  width: 100%
+
   background-color: white
   display: flex
 

--- a/src/components/charts/chart.sass
+++ b/src/components/charts/chart.sass
@@ -1,9 +1,9 @@
 @import ../vars
 
 .chart-container
-
+  position: relative
   background-color: white
-  display: flex
+  display: block
 
   .line-chart-container
     display: flex

--- a/src/components/charts/chart.tsx
+++ b/src/components/charts/chart.tsx
@@ -27,8 +27,8 @@ export class Chart extends React.Component<IChartProps, IChartState> {
     const chart = chartType === "line" ?
       <LineChart
         chartData={chartData}
-        width={this.props.width}
-        height={this.props.height}
+        width={width}
+        height={height}
         isPlaying={isPlaying}
         data-test="line-chart" />
       :

--- a/src/components/charts/line-chart.tsx
+++ b/src/components/charts/line-chart.tsx
@@ -125,7 +125,7 @@ export class LineChart extends BaseComponent<ILineProps, ILineState> {
         text: chartData.name
       },
       scales: {
-        display: false,
+        display: true,
         yAxes: [{
           ticks: {
             min: minMaxValues.minA2,
@@ -133,7 +133,8 @@ export class LineChart extends BaseComponent<ILineProps, ILineState> {
           },
           scaleLabel: {
             display: true,
-            fontSize: 12
+            fontSize: 12,
+            labelString: chartData.a2AxisLabel
           }
         }],
         xAxes: [{
@@ -143,6 +144,11 @@ export class LineChart extends BaseComponent<ILineProps, ILineState> {
             max: minMaxValues.maxA1,
             minRotation: chartData.dataLabelRotation,
             maxRotation: chartData.dataLabelRotation
+          },
+          scaleLabel: {
+            display: true,
+            fontSize: 12,
+            labelString: chartData.a1AxisLabel
           }
         }]
       }

--- a/src/components/controls/control-area.tsx
+++ b/src/components/controls/control-area.tsx
@@ -17,17 +17,11 @@ export class ControlArea extends BaseComponent<{}, {}> {
 
     const { ui } = this.stores;
 
-    const changeShowLabels = (event: any) => {
-      const target = event.currentTarget as HTMLInputElement;
-      ui.setShowLabels(target.checked);
-    };
-
     return (
       <div>
         <hr />
-        <span><b>Temp. Display Controls <i>(To Be Removed!!!)</i></b></span>
+        <span><b>Test SVG Display Controls <i>(Development Only)</i></b></span>
         <br /><br />
-        Show Labels: <input type="checkbox" checked={ui.showLabels} onChange={changeShowLabels} />
         Agriburg Population ({ui.populationAgriburg}):
         <Slider min={0} max={99} value={ui.populationAgriburg} onChange={ui.setPopAgriburg} />
         Farmville Population ({ui.populationFarmville}):

--- a/src/components/dam-data.sass
+++ b/src/components/dam-data.sass
@@ -1,6 +1,5 @@
 .dam-data-grid
   font-size: 0.7em
-  width: 800px
 
   .ag-header-cell
     padding: 2px

--- a/src/components/dam-data.tsx
+++ b/src/components/dam-data.tsx
@@ -8,17 +8,16 @@ import "ag-grid-community/dist/styles/ag-grid.css";
 import "ag-grid-community/dist/styles/ag-theme-balham.css";
 import "./dam-data.sass";
 
-interface IProps extends IBaseProps {}
+interface IProps extends IBaseProps {
+  parentWidth: number;
+  parentHeight: number;
+}
 interface IState { }
 
 const visibleColumns = [
   "Year",
-  "Season",
   "FarmLakeArea",
-  "StartSeasonSurfaceArea",
-  "StartSeasonVolume",
   "EndSeasonSurfaceArea",
-  "EndSeasonVolume",
   "CornYieldFarmville",
   "CornYieldAgriburg"];
 
@@ -28,10 +27,19 @@ export class DamData extends BaseComponent<IProps, IState> {
 
   public render() {
     const { riverData } = this.stores;
+    const { parentWidth, parentHeight } = this.props;
+    const gridStyle: React.CSSProperties = {
+      width: parentWidth,
+      height: parentHeight,
+    };
     const cols = this.getDataColumns();
+    const tableData = dataByFlow(riverData.flowPercentage).filter(d => {
+      if (d.Year <= 10 && d.Season === "Summer") return d;
+      return;
+    });
     return (
-      <div className="dam-data-grid">
-        <AgGridReact columnDefs={cols} rowData={dataByFlow(riverData.flowPercentage)} headerHeight={48}
+      <div className="dam-data-grid" style={gridStyle}>
+        <AgGridReact columnDefs={cols} rowData={tableData} headerHeight={48}
           onGridReady={this.onGridReady} />
       </div>
     );
@@ -45,7 +53,11 @@ export class DamData extends BaseComponent<IProps, IState> {
     Object.keys(allData[0]).map(d => {
       if (visibleColumns.indexOf(d) > -1) {
         const headerName = d.replace(/([A-Z])/g, " $1").trim();
-        const c: ColDef = { headerName, field: d, valueFormatter: this.numberFormatter };
+        const c: ColDef = {
+          headerName, field: d,
+          valueFormatter: this.numberFormatter,
+          width: headerName === "Year" ? 50 : undefined
+        };
         cols.push(c);
       }
     });

--- a/src/components/dam-data.tsx
+++ b/src/components/dam-data.tsx
@@ -14,12 +14,15 @@ interface IProps extends IBaseProps {
 }
 interface IState { }
 
-const visibleColumns = [
+const visibleColumnsCorn = [
   "Year",
-  "FarmLakeArea",
-  "EndSeasonSurfaceArea",
   "CornYieldFarmville",
   "CornYieldAgriburg"];
+
+const visibleColumnsLake = [
+  "Year",
+  "FarmLakeArea",
+  "EndSeasonSurfaceArea"];
 
 @inject("stores")
 @observer
@@ -48,7 +51,7 @@ export class DamData extends BaseComponent<IProps, IState> {
   private getDataColumns = (): ColDef[] => {
     const { riverData } = this.stores;
     const allData = dataByFlow(riverData.flowPercentage);
-
+    const visibleColumns = riverData.dataView === "lake" ? visibleColumnsLake : visibleColumnsCorn;
     const cols: ColDef[] = [];
     Object.keys(allData[0]).map(d => {
       if (visibleColumns.indexOf(d) > -1) {
@@ -56,7 +59,7 @@ export class DamData extends BaseComponent<IProps, IState> {
         const c: ColDef = {
           headerName, field: d,
           valueFormatter: this.numberFormatter,
-          width: headerName === "Year" ? 50 : undefined
+          width: headerName === "Year" ? 50 : 100
         };
         cols.push(c);
       }

--- a/src/components/dam-data.tsx
+++ b/src/components/dam-data.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { BaseComponent, IBaseProps } from "./base";
 import { AgGridReact } from "ag-grid-react";
 import { ColDef, ValueFormatterParams, AgGridEvent } from "ag-grid-community";
-import { dataByFlow } from "../data/dam-data-utility";
+import { dataByFlow, dataByFlowByYear } from "../data/dam-data-utility";
 import "ag-grid-community/dist/styles/ag-grid.css";
 import "ag-grid-community/dist/styles/ag-theme-balham.css";
 import "./dam-data.sass";
@@ -36,7 +36,7 @@ export class DamData extends BaseComponent<IProps, IState> {
       height: parentHeight,
     };
     const cols = this.getDataColumns();
-    const tableData = dataByFlow(riverData.flowPercentage).filter(d => {
+    const tableData = dataByFlowByYear(riverData.flowPercentage, riverData.currentYear).filter(d => {
       if (d.Year <= 10 && d.Season === "Summer") return d;
       return;
     });
@@ -50,7 +50,7 @@ export class DamData extends BaseComponent<IProps, IState> {
 
   private getDataColumns = (): ColDef[] => {
     const { riverData } = this.stores;
-    const allData = dataByFlow(riverData.flowPercentage);
+    const allData = dataByFlowByYear(riverData.flowPercentage, riverData.currentYear);
     const visibleColumns = riverData.dataView === "lake" ? visibleColumnsLake : visibleColumnsCorn;
     const cols: ColDef[] = [];
     Object.keys(allData[0]).map(d => {

--- a/src/components/simulation-controls.sass
+++ b/src/components/simulation-controls.sass
@@ -1,13 +1,7 @@
 @import vars
 
 .simulation-controls
-
-  background-color: $left-nav-bgcolor
-  margin-right: $component-margin
-  background-color: $section-bgcolor
-  color: $color-nav-cinder-dark3
-  padding: $half-padding
-
+  padding-left: 10px
   font-size: 0.8em
 
   div

--- a/src/components/simulation-controls.tsx
+++ b/src/components/simulation-controls.tsx
@@ -12,7 +12,7 @@ interface IState {}
 @observer
 export class SimulationControls extends BaseComponent<IProps, IState> {
   public render() {
-    const { riverData, ui } = this.stores;
+    const { riverData, ui, appMode } = this.stores;
     const allData = dataByFlow(riverData.flowPercentage);
     const dataToDisplay =
       allData.filter(d => d.Year === riverData.currentYear && d.Season === riverData.currentSeason)[0];
@@ -31,20 +31,26 @@ export class SimulationControls extends BaseComponent<IProps, IState> {
           min={1}
           max={10}
           value={riverData.currentYear}
-          />
-        <div>Season: {riverData.currentSeason}</div>
-        <select onChange={this.handleSeasonChange} value={riverData.currentSeason}>
-          <option value="Spring">Spring</option>
-          <option value="Summer">Summer</option>
-        </select>
-        <div>End of Season Area: {dataToDisplay.EndSeasonSurfaceArea}</div>
-        <div className="display-mode">Display Mode</div>
-        <div><input type="radio" id="displayModeSim" name="displayMode" value="Simulation"
-          checked={ui.displayMode === "Simulation"} onChange={this.handleDisplayModeChange}/>Simulation</div>
-        <div><input type="radio" id="displayModeGraph" name="displayMode" value="Graph"
-          checked={ui.displayMode === "Graph"} onChange={this.handleDisplayModeChange}/>Graph</div>
-        <div><input type="radio" id="displayModeTable" name="displayMode" value="Table"
-          checked={ui.displayMode === "Table"} onChange={this.handleDisplayModeChange}/>Table</div>
+        />
+        <div>Show Labels: </div><input type="checkbox" checked={ui.showLabels} onChange={this.handleShowLabelsChange} />
+
+        {appMode === "dev" &&
+          <div>
+          <div>Season: {riverData.currentSeason}</div>
+          <select onChange={this.handleSeasonChange} value={riverData.currentSeason}>
+            <option value="Spring">Spring</option>
+            <option value="Summer">Summer</option>
+          </select>
+          <div>End of Season Area: {dataToDisplay.EndSeasonSurfaceArea}</div>
+          <div className="display-mode">Display Mode</div>
+          <div><input type="radio" id="displayModeSim" name="displayMode" value="Simulation"
+            checked={ui.displayMode === "Simulation"} onChange={this.handleDisplayModeChange} />Simulation</div>
+          <div><input type="radio" id="displayModeGraph" name="displayMode" value="Graph"
+            checked={ui.displayMode === "Graph"} onChange={this.handleDisplayModeChange} />Graph</div>
+          <div><input type="radio" id="displayModeTable" name="displayMode" value="Table"
+            checked={ui.displayMode === "Table"} onChange={this.handleDisplayModeChange} />Table</div>
+          </div>
+        }
         {this.props.children}
       </div>
     );
@@ -65,5 +71,10 @@ export class SimulationControls extends BaseComponent<IProps, IState> {
   private handleDisplayModeChange = (e: React.FormEvent<HTMLInputElement>) => {
     const { ui } = this.stores;
     ui.setDisplayMode(e.currentTarget.value);
+  }
+  private handleShowLabelsChange = (e: React.FormEvent<HTMLInputElement>) => {
+    const { ui } = this.stores;
+    console.log(e.currentTarget.checked);
+    ui.setShowLabels(e.currentTarget.checked);
   }
 }

--- a/src/components/simulation-controls.tsx
+++ b/src/components/simulation-controls.tsx
@@ -74,7 +74,6 @@ export class SimulationControls extends BaseComponent<IProps, IState> {
   }
   private handleShowLabelsChange = (e: React.FormEvent<HTMLInputElement>) => {
     const { ui } = this.stores;
-    console.log(e.currentTarget.checked);
     ui.setShowLabels(e.currentTarget.checked);
   }
 }

--- a/src/data/dam-data-utility.ts
+++ b/src/data/dam-data-utility.ts
@@ -11,6 +11,14 @@ export function dataByFlow(flowPercentage: number): SeasonData[] {
   if (flowPercentage === 75) allData = dam75 as SeasonData[];
   return allData;
 }
+export function dataByFlowByYear(flowPercentage: number, year: number): SeasonData[] {
+  let allData: SeasonData[] = dam0 as SeasonData[];
+  if (flowPercentage === 0) allData = dam0 as SeasonData[];
+  if (flowPercentage === 25) allData = dam25 as SeasonData[];
+  if (flowPercentage === 50) allData = dam50 as SeasonData[];
+  if (flowPercentage === 75) allData = dam75 as SeasonData[];
+  return allData.filter(d => d.Year <= year);
+}
 
 export interface SeasonData {
     Year: number;

--- a/src/models/charts/chart-data-set.ts
+++ b/src/models/charts/chart-data-set.ts
@@ -76,7 +76,9 @@ export const ChartDataSetModel = types
     expandOnly: false,
     fixedLabelRotation: types.maybe(types.number),
     dataStartIdx: types.maybe(types.number),
-    stack: types.maybe(types.string)
+    stack: types.maybe(types.string),
+    a1AxisLabel: types.maybe(types.string),
+    a2AxisLabel: types.maybe(types.string)
   })
   .views(self => ({
     get visibleDataPoints() {

--- a/src/models/charts/chart-data.ts
+++ b/src/models/charts/chart-data.ts
@@ -60,6 +60,12 @@ export const ChartDataModel = types
 
     get subsetIdx() {
       return self.dataSets[0].dataStartIdx;
+    },
+    get a1AxisLabel() {
+      return self.dataSets[0].a1AxisLabel;
+    },
+    get a2AxisLabel() {
+      return self.dataSets[0].a2AxisLabel;
     }
   }))
   .extend(self => {

--- a/src/models/dam.ts
+++ b/src/models/dam.ts
@@ -4,7 +4,8 @@ export const DamModel = types
   .model("Dam", {
     flowPercentage: 0,
     currentYear: 1,
-    currentSeason: "Spring"
+    currentSeason: "Spring",
+    dataView: "lake"
   })
   .actions(self => ({
     setFlowPercentage(flow: number) {
@@ -15,6 +16,9 @@ export const DamModel = types
     },
     setSeason(season: string) {
       self.currentSeason = season;
+    },
+    setDataView(dataView: string) {
+      self.dataView = dataView;
     }
   }))
   ;

--- a/src/models/stores.ts
+++ b/src/models/stores.ts
@@ -17,7 +17,7 @@ export interface ICreateStores {
 
 export function createStores(params?: ICreateStores): IStores {
   return {
-    appMode: params && params.appMode ? params.appMode : "dev",
+    appMode: params && params.appMode ? params.appMode : "live",
     ui: params && params.ui || UIModel.create({}),
     riverData: params && params.riverData || DamModel.create()
   };


### PR DESCRIPTION
Switching between corn and water levels now links tables and charts. Added some sensible min-max values for the axes.
Axis labels have been added, the layout has been adjusted to show the controls at the bottom
Live mode is now default, so I've hidden some of the original simulation controls to only display if in dev mode (other controls can be adjusted similarly)
Year-on-year data now displays as the timeline scrubber is dragged