### PR TITLE
163437630 improve population rendering

### DIFF
--- a/src/components/picture/picture-area.tsx
+++ b/src/components/picture/picture-area.tsx
@@ -542,6 +542,7 @@ export class PictureArea extends BaseComponent<IProps, {}> {
     // one of values in the set fixed values { 0, 25, 50, 75 }, the remaining
     // values are in the range 0..100.
 
+    if (isDev || appMode === "displayOnConsole") {
     // tslint:disable-next-line no-console
     console.log(`%  lake  AC  FC  AP  FP\n` +
                 `${flowPercentage}\t` +
@@ -550,6 +551,7 @@ export class PictureArea extends BaseComponent<IProps, {}> {
                 `${Math.round(currentCropsFarmville)}\t` +
                 `${Math.round(populationAgriburg)}\t` +
                 `${Math.round(populationFarmville)}`);
+    }
 
     return (
       <div className="picture-area-container">

--- a/src/components/picture/picture-area.tsx
+++ b/src/components/picture/picture-area.tsx
@@ -160,7 +160,7 @@ export class PictureArea extends BaseComponent<IProps, {}> {
 
   public render() {
 
-    const { riverData, ui } = this.stores;
+    const { riverData, ui, appMode } = this.stores;
 
     const { parentWidth, parentHeight } = this.props;
 
@@ -333,8 +333,26 @@ export class PictureArea extends BaseComponent<IProps, {}> {
       );
     };
 
+    // The parameter, crops, is expected to be in the range 0..100. The number
+    // of farms, which is representbed by the number of barns displayed in each
+    // town's farm-land, is mapped like this:
+    //
+    // |  crops  | barns |
+    // |---------|-------|
+    // |    0    |   0   |
+    // |  1..32  |   1   |
+    // |  33..64 |   2   |
+    // | 65..100 |   3   |
     const howManyFarms = (crops: number) => {
-      return crops / 25;
+      if (crops <= 0) {
+        return 0;
+      } else if (crops <= 32) {
+        return 1;
+      } else if (crops <= 64) {
+        return 2;
+      } else {
+        return 3;
+      }
     };
 
     const renderFarms = (crops: number, barns: IBarn[]) => {
@@ -358,7 +376,7 @@ export class PictureArea extends BaseComponent<IProps, {}> {
     };
 
     const barnsFarmville: IBarn[] =  [
-      {x: 450, y: 132},
+      {x: 450, y: 125},
       {x: 398, y: 168},
       {x: 519, y: 177}
     ];
@@ -369,8 +387,33 @@ export class PictureArea extends BaseComponent<IProps, {}> {
       {x: 465, y: 307}
     ];
 
+    // The parameter, crops, is expected to be in the range 0..100. The number
+    // of agricultural areas, which is represented by the number of corn fields
+    // displayed in each town's farm-land, is mapped like this:
+    //
+    // |  crops  | corn fields |
+    // |---------|-------------|
+    // |  0..5   |      0      |
+    // |  6..25  |      1      |
+    // | 26..45  |      2      |
+    // | 46..65  |      3      |
+    // | 66..85  |      4      |
+    // | 86..100 |      5      |
+
     const howManyFields = (crops: number, fields: ICornField[]) => {
-      return crops / fields.length;
+      if (crops <= 5) {
+        return 0;
+      } else if (crops <= 25) {
+        return 1;
+      } else if (crops <= 45) {
+        return 2;
+      } else if (crops <= 65) {
+        return 3;
+      } else if (crops <= 85) {
+        return 4;
+      } else {
+        return 5;
+      }
     };
 
     const renderCornFields = (crops: number, fields: ICornField[]) => {
@@ -485,13 +528,15 @@ export class PictureArea extends BaseComponent<IProps, {}> {
     // (or perhaps, resolution) to make it look good. That's a different
     // problem.
 
+    const isDev = appMode === "dev";
+
     const showLabels = ui.showLabels;
     const flowPercentage = riverData.flowPercentage;
-    const currentLakeArea = riverData.getCurrentLakeArea();
-    const currentCropsAgriburg = riverData.getCropsAgriburg();
-    const currentCropsFarmville = riverData.getCropsFarmville();
-    const populationAgriburg = riverData.getResidentialUseAgriburg();
-    const populationFarmville = riverData.getResidentialUseFarmville();
+    const currentLakeArea = isDev ? ui.lakeArea : riverData.getCurrentLakeArea();
+    const currentCropsAgriburg = isDev ? ui.cropsArgiburg : riverData.getCropsAgriburg();
+    const currentCropsFarmville = isDev ? ui.cropsFarmville : riverData.getCropsFarmville();
+    const populationAgriburg = isDev ? ui.populationAgriburg : riverData.getResidentialUseAgriburg();
+    const populationFarmville = isDev ? ui.populationFarmville : riverData.getResidentialUseFarmville();
 
     // Except for showLabels, which is a boolean, and flowPercentage, which is
     // one of values in the set fixed values { 0, 25, 50, 75 }, the remaining

--- a/src/data/dam-data-utility.ts
+++ b/src/data/dam-data-utility.ts
@@ -74,6 +74,7 @@ export interface SeasonData {
     WaterDemandCorn: number;
     WaterNeeded: number;
 }
+
 function blankSeasonData(year: number): SeasonData {
   const blankData: SeasonData = {
     Year: year,
@@ -136,6 +137,20 @@ function getMinMaxLakeArea(): DataMinMax {
   return { Max: maxArea, Min: minArea };
 }
 
+function getMinMaxResidentialUseAgriburg(): DataMinMax {
+  const data = _allData();
+  const maxResidentialUse = Math.max(...data.map(p => p.AgriburgResidentialUse));
+  const minResidentialUse = Math.min(...data.map(p => p.AgriburgResidentialUse));
+  return { Max: maxResidentialUse, Min: minResidentialUse};
+}
+
+function getMinMaxResidentialUseFarmville(): DataMinMax {
+  const data = _allData();
+  const maxResidentialUse = Math.max(...data.map(p => p.FarmvilleResidentialUse));
+  const minResidentialUse = Math.min(...data.map(p => p.FarmvilleResidentialUse));
+  return { Max: maxResidentialUse, Min: minResidentialUse};
+}
+
 export function getCurrentCropPercentageAgriburg(flowPercentage: number, year: number): number {
   const minmax = getMinMaxCropsAgriburg();
   const currentValue = dataByFlowForSpecificYear(flowPercentage, year).CornYieldAgriburg;
@@ -149,6 +164,18 @@ export function getCurrentCropPercentageFarmville(flowPercentage: number, year: 
 export function getCurrentLakeArea(flowPercentage: number, year: number): number {
   const minmax = getMinMaxLakeArea();
   const currentValue = dataByFlowForSpecificYear(flowPercentage, year).EndSeasonSurfaceArea;
+  return calcValue(minmax, currentValue);
+}
+
+export function getCurrentPercentageAgriburgResidentialUse(flowPercentage: number, year: number): number {
+  const minmax = getMinMaxResidentialUseAgriburg();
+  const currentValue = dataByFlowForSpecificYear(flowPercentage, year).AgriburgResidentialUse;
+  return calcValue(minmax, currentValue);
+}
+
+export function getCurrentPercentageFarmvilleResidentialUse(flowPercentage: number, year: number): number {
+  const minmax = getMinMaxResidentialUseFarmville();
+  const currentValue = dataByFlowForSpecificYear(flowPercentage, year).FarmvilleResidentialUse;
   return calcValue(minmax, currentValue);
 }
 

--- a/src/models/dam.ts
+++ b/src/models/dam.ts
@@ -2,7 +2,9 @@ import { types, Instance } from "mobx-state-tree";
 import {
   getCurrentCropPercentageAgriburg,
   getCurrentCropPercentageFarmville,
-  getCurrentLakeArea
+  getCurrentLakeArea,
+  getCurrentPercentageAgriburgResidentialUse,
+  getCurrentPercentageFarmvilleResidentialUse
 } from "../data/dam-data-utility";
 
 export const DamModel = types
@@ -23,7 +25,14 @@ export const DamModel = types
       },
       getCurrentLakeArea() {
         return (getCurrentLakeArea(self.flowPercentage, self.currentYear));
+      },
+      getResidentialUseAgriburg() {
+        return (getCurrentPercentageAgriburgResidentialUse(self.flowPercentage, self.currentYear));
+      },
+      getResidentialUseFarmville() {
+        return (getCurrentPercentageFarmvilleResidentialUse(self.flowPercentage, self.currentYear));
       }
+
     };
   })
   .actions(self => ({

--- a/src/models/stores.ts
+++ b/src/models/stores.ts
@@ -1,7 +1,7 @@
 import { UIModel, UIModelType } from "./ui";
 import { DamModel, DamModelType } from "./dam";
 
-export type AppMode = "live" | "dev" | "embed" ;
+export type AppMode = "live" | "dev" | "displayOnConsole" | "embed" ;
 
 export interface IStores {
   appMode: AppMode;


### PR DESCRIPTION
This PR addresses some problems with rendering populations, crops, and farms. In particular, it "hooks up" the simulation data to the display. Changes address:

* Added data model access for residential water volume usage for both towns.

* Reconnected driving display from sliders when appMode is set to "dev".

* Fine tuned computation maps for number of farms (barns) and crops (corn-fields).

* Adjust location of Farmville barns so they aren't in the river during high-water times.

* More descriptive comments for the arithmetic.

* Added a `console.log()` output of the control inputs to the display. These data are shown in the console if either appMode=dev or appMode=displayOnConsole. Use the "displayOnConsole" to see the data from the simulation data store. Use "dev" to control the display using sliders, independent of the data store.
