### PR TITLE
Adjust data table styling

### DIFF
--- a/src/components/app.sass
+++ b/src/components/app.sass
@@ -62,7 +62,7 @@
 
         &.chart-table
           display: grid
-          grid-template-rows: 28px 290px auto
+          grid-template-rows: 28px 270px auto
           flex: 1 1 auto
 
           .subsection

--- a/src/components/attribution.css
+++ b/src/components/attribution.css
@@ -32,7 +32,7 @@
 
 .attribution-text{
   position: absolute;
-  font-size: 0.9em;
+  font-size: 14px;
   top: 50%;
   left: 50%;
   margin: -200px 0 0 -150px;

--- a/src/components/attribution.tsx
+++ b/src/components/attribution.tsx
@@ -20,8 +20,7 @@ export class Attribution extends BaseComponent<IProps, IAttributionState> {
     <div className={attributionDisplayClass} onClick={this.toggleAttribution}>
       <div className="attribution-text">
         <div className="small-logo" onClick={this.toggleAttribution} />
-          <div>This interactive was created by the Concord Consortium in
-          collaboration with Indiana University and the Educational Testing Service.
+          <div>
           This simulation was developed by Concord Consortium in collaboration with Indiana University
           and Educational Testing Service under the grant: DAT-CROSS: Developing Assessments
           and Tools to Support the Teaching and Learning of Science Crosscutting Concepts

--- a/src/components/charts/bar-chart.tsx
+++ b/src/components/charts/bar-chart.tsx
@@ -24,7 +24,7 @@ const defaultOptions: ChartOptions = {
   },
   legend: {
     display: true,
-    position: "bottom",
+    position: "top",
     labels: {
       boxWidth: 12,
       fontSize: 11

--- a/src/components/charts/chart-display.tsx
+++ b/src/components/charts/chart-display.tsx
@@ -88,7 +88,7 @@ export class ChartDisplay extends BaseComponent<IProps, IState> {
     const { riverData } = this.stores;
 
     const cornAgriburgDataSet = ChartDataSetModel.create({
-      name: "Corn Yield Agriburg",
+      name: "Agriburg",
       dataPoints: this.buildChart(sourceData, "Summer", "corna"),
       color: ChartColors[3].hex,
       backgroundOpacity: 0.9,
@@ -101,7 +101,7 @@ export class ChartDisplay extends BaseComponent<IProps, IState> {
     });
 
     const cornFarmvilleDataSet = ChartDataSetModel.create({
-      name: "Corn Yield Farmville",
+      name: "Farmville",
       dataPoints: this.buildChart(sourceData, "Summer", "cornf"),
       color: ChartColors[1].hex,
       backgroundOpacity: 0.9,

--- a/src/components/charts/chart.sass
+++ b/src/components/charts/chart.sass
@@ -31,7 +31,6 @@
     float: left
     text-align: center
     background: $color-white
-    font-size: 0.9em
     opacity: 0.7
     padding: 2px
     &:hover

--- a/src/components/charts/line-chart.tsx
+++ b/src/components/charts/line-chart.tsx
@@ -28,7 +28,7 @@ const defaultOptions: ChartOptions = {
   },
   legend: {
     display: true,
-    position: "bottom",
+    position: "top",
     labels: {
       usePointStyle: true,
       fontSize: 11

--- a/src/components/controls/data-controls.sass
+++ b/src/components/controls/data-controls.sass
@@ -15,7 +15,7 @@
     border-bottom: 0
     border-top-left-radius: 4px
     border-top-right-radius: 4px
-    font-size: 0.7em
+    font-size: 11px
     opacity: 0.7
     padding: 2px 0px
     white-space: nowrap

--- a/src/components/controls/simulation-controls.sass
+++ b/src/components/controls/simulation-controls.sass
@@ -8,7 +8,7 @@
 
 .simulation-controls
   padding-left: 10px
-  font-size: 0.8em
+  font-size: 14px
   min-width: 300px
   text-align: center
 

--- a/src/components/dam-data.sass
+++ b/src/components/dam-data.sass
@@ -1,7 +1,7 @@
 @import ./vars
 
 .dam-data-grid
-  font-size: 0.7em
+  font-size: 11px
   max-width: 325px
   margin-left: auto
   margin-right: auto

--- a/src/components/dam-data.sass
+++ b/src/components/dam-data.sass
@@ -1,14 +1,38 @@
+@import ./vars
+
 .dam-data-grid
   font-size: 0.7em
+  max-width: 325px
+  margin-left: auto
+  margin-right: auto
+  text-align: center
+  overflow: hidden
 
   .ag-header-cell
     padding: 2px
+    border-bottom: 1px solid silver
   .ag-header-cell-label
     text-overflow: clip
     overflow: visible
     white-space: normal
     font-weight: 700
+
   .ag-cell
     padding: 0
+    padding-top: 2px
+    border: 1px dotted #eeeeee
     &.dam-value
-      padding-left: 25px
+      padding-left: 0px
+      &.lake
+        &.value1
+          background-color: $color-nav-cerulean-light2
+        &.value2
+          background-color: $color-nav-cerulean-light1
+      &.corn
+        &.value1
+          background-color: $color-khaki-yellow-light2
+        &.value2
+          background-color: $color-nav-shamrock-light2
+
+    &.dam-year
+      padding-left: 0px

--- a/src/components/dam-data.tsx
+++ b/src/components/dam-data.tsx
@@ -20,8 +20,12 @@ const visibleColumnsCorn = [
   "CornYieldAgriburg"];
 
 const lakeColumnHeaders = {
-  FarmLakeArea: "Start Season Area",
-  EndSeasonSurfaceArea: "End Season Area"
+  FarmLakeArea: "Start Season Area (acre)",
+  EndSeasonSurfaceArea: "End Season Area (acre)"
+};
+const cornColumnHeaders = {
+  CornYieldFarmville: "Corn Yield Farmville (bu/acre)",
+  CornYieldAgriburg: "Corn Yield Agriburg (bu/acre)"
 };
 
 const visibleColumnsLake = [
@@ -32,12 +36,11 @@ const visibleColumnsLake = [
 @inject("stores")
 @observer
 export class DamData extends BaseComponent<IProps, IState> {
-
   public render() {
     const { riverData } = this.stores;
     const { parentWidth, parentHeight } = this.props;
     const gridStyle: React.CSSProperties = {
-      width: parentWidth,
+      width: parentWidth && parentWidth > 300 ? parentWidth : 300,
       height: parentHeight,
       maxHeight: "300px"
     };
@@ -48,8 +51,8 @@ export class DamData extends BaseComponent<IProps, IState> {
     });
     return (
       <div className="dam-data-grid" style={gridStyle}>
-        <AgGridReact columnDefs={cols} rowData={tableData} headerHeight={24}
-          onGridReady={this.onGridReady} />
+        <AgGridReact columnDefs={cols} rowData={tableData} headerHeight={30} rowHeight={22}
+          onGridReady={this.onGridReady} onNewColumnsLoaded={this.onGridReady} />
       </div>
     );
   }
@@ -70,6 +73,12 @@ export class DamData extends BaseComponent<IProps, IState> {
         if (d === "EndSeasonSurfaceArea") {
           headerName = lakeColumnHeaders.EndSeasonSurfaceArea;
         }
+        if (d === "CornYieldAgriburg") {
+          headerName = cornColumnHeaders.CornYieldAgriburg;
+        }
+        if (d === "CornYieldFarmville") {
+          headerName = cornColumnHeaders.CornYieldFarmville;
+        }
         const c: ColDef = {
           headerName, field: d,
           valueFormatter: this.numberFormatter,
@@ -82,6 +91,11 @@ export class DamData extends BaseComponent<IProps, IState> {
           c.suppressSizeToFit = true;
           c.cellClass = "dam-year";
         }
+        if (visibleColumns.indexOf(d) !== 0) {
+          c.cellClass += " value" + visibleColumns.indexOf(d);
+        }
+        c.cellClass += " " + riverData.dataView;
+
         cols.push(c);
       }
     });


### PR DESCRIPTION
Lots of styling for charts, added different colors to the table (ensuring Agriburg and Farmville retain their signature green / orange style to match the charts) and centered up the table on the page.
Header now wraps, increasing the size of the header, but rows have been compacted a little to compensate.
Fix duplicated text in attribution